### PR TITLE
Update Countries.php for Sweden

### DIFF
--- a/src/Countries.php
+++ b/src/Countries.php
@@ -62,8 +62,8 @@ final class Countries
             'currency' => 'EUR',
         ],
         [
-            'country'  => 'sv',
-            'locale' => 'sv',
+            'country'  => 'se',
+            'locale' => 'se',
             'currency' => 'EUR',
         ],
         [


### PR DESCRIPTION
.se is a official country code for Sweden and .sv creates problems when using something like google maps API's as it returns results for El Salvador.